### PR TITLE
Append path to Link header

### DIFF
--- a/index.js
+++ b/index.js
@@ -360,7 +360,7 @@ export default async function makeHyperFetch ({
     const resHeaders = {
       ETag: `${drive.version}`,
       'Accept-Ranges': 'bytes',
-      Link: `<${drive.core.url}>; rel="canonical"`
+      Link: `<${drive.core.url}${pathname.substring(1)}>; rel="canonical"`
     }
 
     if (isDirectory) {
@@ -463,7 +463,7 @@ export default async function makeHyperFetch ({
     if (isDirectory) {
       const resHeaders = {
         ETag: `${drive.version}`,
-        Link: `<${drive.core.url}>; rel="canonical"`
+        Link: `<${drive.core.url}${pathname.substring(1)}>; rel="canonical"`
       }
 
       const entries = await listEntries(drive, pathname)
@@ -529,7 +529,7 @@ async function serveFile (headers, drive, pathname) {
     ETag: `${entry.seq}`,
     [HEADER_CONTENT_TYPE]: contentType,
     'Accept-Ranges': 'bytes',
-    Link: `<${drive.core.url}>; rel="canonical"`
+    Link: `<${drive.core.url}${pathname.substring(1)}>; rel="canonical"`
   }
 
   if (entry.metadata?.mtime) {

--- a/test.js
+++ b/test.js
@@ -73,6 +73,9 @@ test('Quick check', async (t) => {
   const content = await uploadedContentResponse.text()
   const contentType = uploadedContentResponse.headers.get('Content-Type')
 
+  const contentLink = uploadedContentResponse.headers.get('Link')
+  t.match(contentLink, /^<hyper:\/\/[0-9a-z]{52}\/example.txt>; rel="canonical"$/, 'Link header includes both public key and path.')
+
   t.equal(contentType, 'text/plain; charset=utf-8', 'Content got expected mime type')
   t.equal(content, SAMPLE_CONTENT, 'Got uploaded content back out')
 


### PR DESCRIPTION
Unlike the solution in v8.6.1:

```
const canonical = `hyper://${archive.key.toString('hex')}${path || ''}`
responseHeaders.Link = `<${canonical}>; rel="canonical"
```
it is not necessary to use `pathname || ''`, since pathname will always contain at least '/'. In that case, Array.substring correctly leaves behind the empty string.

Resolves #42