### PR TITLE
Add failing test to demonstrate uri-encoding

### DIFF
--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ test('Quick check', async (t) => {
 
   t.deepEqual(await existsResponse.json(), [], 'Empty dir on create')
 
-  const uploadLocation = new URL('./example.txt', created)
+  const uploadLocation = new URL('./example .txt', created)
 
   const uploadResponse = await fetch(uploadLocation, {
     method: 'put',
@@ -74,7 +74,7 @@ test('Quick check', async (t) => {
   const contentType = uploadedContentResponse.headers.get('Content-Type')
   const contentLink = uploadedContentResponse.headers.get('Link')
 
-  t.match(contentLink, /^<hyper:\/\/[0-9a-z]{52}\/example.txt>; rel="canonical"$/, 'Link header includes both public key and path.')
+  t.match(contentLink, /^<hyper:\/\/[0-9a-z]{52}\/example .txt>; rel="canonical"$/, 'Link header includes both public key and path.')
   t.equal(contentType, 'text/plain; charset=utf-8', 'Content got expected mime type')
   t.equal(content, SAMPLE_CONTENT, 'Got uploaded content back out')
 


### PR DESCRIPTION
I'm assuming that the Link header should have a space and not `%20`? Feel free to close this if this behavior is expected.

If this is actually an issue, this is still a quick and dirty test. If you want me to split it out into a separate test, lmk.