### PR TITLE
Test: PUT multipart/formdata commits changes atomically

### DIFF
--- a/test.js
+++ b/test.js
@@ -186,6 +186,12 @@ test('PUT FormData', async (t) => {
   await checkResponse(listDirRequest, t)
   const entries = await listDirRequest.json()
   t.deepEqual(entries, ['example.txt', 'example2.txt'], 'new files are listed')
+
+  const headResponse = await fetch(created, { method: 'head' })
+  await checkResponse(headResponse, t)
+  const etag = headResponse.headers.get('Etag')
+
+  t.equal(etag, 2, 'Both files uploaded in one atomic commit.')
 })
 test('PUT into new directory', async (t) => {
   const created = await nextURL(t)


### PR DESCRIPTION
We should probably use drive.batch() to commit changes in multipart/formdata PUT requests.