### PR TITLE
Handle empty string pathname

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,7 +244,7 @@ export default async function makeHyperFetch ({
 
   async function listenExtension (request) {
     const { hostname, pathname: rawPathname } = new URL(request.url)
-    const pathname = decodeURI(rawPathname)
+    const pathname = decodeURI(ensureLeadingSlash(rawPathname))
     const name = pathname.slice(`/${SPECIAL_FOLDER}/${EXTENSIONS_FOLDER_NAME}/`.length)
 
     const core = await getCore(`hyper://${hostname}/`)
@@ -266,7 +266,7 @@ export default async function makeHyperFetch ({
 
   async function broadcastExtension (request) {
     const { hostname, pathname: rawPathname } = new URL(request.url)
-    const pathname = decodeURI(rawPathname)
+    const pathname = decodeURI(ensureLeadingSlash(rawPathname))
 
     const name = pathname.slice(`/${SPECIAL_FOLDER}/${EXTENSIONS_FOLDER_NAME}/`.length)
 
@@ -281,7 +281,7 @@ export default async function makeHyperFetch ({
 
   async function extensionToPeer (request) {
     const { hostname, pathname: rawPathname } = new URL(request.url)
-    const pathname = decodeURI(rawPathname)
+    const pathname = decodeURI(ensureLeadingSlash(rawPathname))
 
     const subFolder = pathname.slice(`/${SPECIAL_FOLDER}/${EXTENSIONS_FOLDER_NAME}/`.length)
     const [name, extensionPeer] = subFolder.split('/')
@@ -345,7 +345,7 @@ export default async function makeHyperFetch ({
 
   async function putFiles (request) {
     const { hostname, pathname: rawPathname } = new URL(request.url)
-    const pathname = decodeURI(rawPathname)
+    const pathname = decodeURI(ensureLeadingSlash(rawPathname))
     const contentType = request.headers.get('Content-Type') || ''
     const isFormData = contentType.includes('multipart/form-data')
 
@@ -382,7 +382,7 @@ export default async function makeHyperFetch ({
 
   async function deleteFiles (request) {
     const { hostname, pathname: rawPathname } = new URL(request.url)
-    const pathname = decodeURI(rawPathname)
+    const pathname = decodeURI(ensureLeadingSlash(rawPathname))
 
     const drive = await getDrive(`hyper://${hostname}`)
 
@@ -411,7 +411,7 @@ export default async function makeHyperFetch ({
   async function headFilesVersioned (request) {
     const url = new URL(request.url)
     const { hostname, pathname: rawPathname, searchParams } = url
-    const pathname = decodeURI(rawPathname)
+    const pathname = decodeURI(ensureLeadingSlash(rawPathname))
 
     const accept = request.headers.get('Accept') || ''
     const isRanged = request.headers.get('Range') || ''
@@ -431,7 +431,7 @@ export default async function makeHyperFetch ({
   async function headFiles (request) {
     const url = new URL(request.url)
     const { hostname, pathname: rawPathname, searchParams } = url
-    const pathname = decodeURI(rawPathname)
+    const pathname = decodeURI(ensureLeadingSlash(rawPathname))
 
     const accept = request.headers.get('Accept') || ''
     const isRanged = request.headers.get('Range') || ''
@@ -546,7 +546,7 @@ export default async function makeHyperFetch ({
   async function getFilesVersioned (request) {
     const url = new URL(request.url)
     const { hostname, pathname: rawPathname, searchParams } = url
-    const pathname = decodeURI(rawPathname)
+    const pathname = decodeURI(ensureLeadingSlash(rawPathname))
 
     const accept = request.headers.get('Accept') || ''
     const isRanged = request.headers.get('Range') || ''
@@ -567,7 +567,7 @@ export default async function makeHyperFetch ({
   async function getFiles (request) {
     const url = new URL(request.url)
     const { hostname, pathname: rawPathname, searchParams } = url
-    const pathname = decodeURI(rawPathname)
+    const pathname = decodeURI(ensureLeadingSlash(rawPathname))
 
     const accept = request.headers.get('Accept') || ''
     const isRanged = request.headers.get('Range') || ''

--- a/index.js
+++ b/index.js
@@ -749,3 +749,7 @@ function getMimeType (path) {
   if (mimeType.startsWith('text/')) mimeType = `${mimeType}; charset=utf-8`
   return mimeType
 }
+
+function ensureLeadingSlash (path) {
+  return path.startsWith('/') ? path : '/' + path
+}

--- a/index.js
+++ b/index.js
@@ -419,7 +419,7 @@ export default async function makeHyperFetch ({
 
     const parts = pathname.split('/')
     const version = parts[3]
-    const realPath = parts.slice(4).join('/')
+    const realPath = ensureLeadingSlash(parts.slice(4).join('/'))
 
     const drive = await getDrive(`hyper://${hostname}`)
 
@@ -554,7 +554,7 @@ export default async function makeHyperFetch ({
 
     const parts = pathname.split('/')
     const version = parts[3]
-    const realPath = parts.slice(4).join('/')
+    const realPath = ensureLeadingSlash(parts.slice(4).join('/'))
 
     const drive = await getDrive(`hyper://${hostname}`)
 

--- a/index.js
+++ b/index.js
@@ -367,14 +367,18 @@ export default async function makeHyperFetch ({
         )
       }
     } else {
-      await pipelinePromise(
-        Readable.from(request.body),
-        drive.createWriteStream(pathname, {
-          metadata: {
-            mtime: Date.now()
-          }
-        })
-      )
+      if (pathname.endsWith('/')) {
+        return { status: 405, body: 'Cannot PUT file with trailing slash', headers: { Location: request.url } }
+      } else {
+        await pipelinePromise(
+          Readable.from(request.body),
+          drive.createWriteStream(pathname, {
+            metadata: {
+              mtime: Date.now()
+            }
+          })
+        )
+      }
     }
 
     return { status: 201, headers: { Location: request.url } }

--- a/test.js
+++ b/test.js
@@ -514,6 +514,57 @@ test('GET older version of file from VERSION folder', async (t) => {
   t.deepEqual(versionedRootContents, [], 'Old root content got loaded')
 })
 
+test.only('Handle empty string pathname', async (t) => {
+  const created = await nextURL(t)
+  const urlObject = new URL('', created)
+  const urlNoTrailingSlash = urlObject.href.slice(0,-1)
+  const versionedURLObject = new URL(`/$/version/3/`, created)
+  const versionedURLNoTrailingSlash = versionedURLObject.href.slice(0,-1)
+
+  // PUT
+  const putResponse = await fetch(urlNoTrailingSlash, { method: 'PUT', body: SAMPLE_CONTENT })
+  if (putResponse.ok) {
+    throw new Error('PUT file at the root directory should have failed')
+  } else {
+    t.pass('PUT file at root directory threw an error')
+  }
+
+  // PUT FormData
+  const formData = new FormData()
+  formData.append('file', new Blob([SAMPLE_CONTENT]), 'example.txt')
+  formData.append('file', new Blob([SAMPLE_CONTENT]), 'example2.txt')
+
+  await checkResponse(
+    await fetch(urlNoTrailingSlash, {
+      method: 'put',
+      body: formData
+    }), t
+  )
+
+  // DELETE
+  await checkResponse(await fetch(urlNoTrailingSlash, { method: 'DELETE' }), t)
+
+  // HEAD
+  const headResponse = await fetch(urlNoTrailingSlash, { method: 'HEAD' })
+  await checkResponse(headResponse, t)
+  t.deepEqual(headResponse.headers.get('Etag'), '5', 'HEAD request returns correct Etag')
+
+  // HEAD (versioned)
+  const versionedHeadResponse = await fetch(versionedURLNoTrailingSlash, { method: 'HEAD' })
+  await checkResponse(versionedHeadResponse, t)
+  t.deepEqual(versionedHeadResponse.headers.get('Etag'), '3', 'Versioned HEAD request returns correct Etag')
+
+  // GET
+  const getResponse = await fetch(urlNoTrailingSlash)
+  await checkResponse(getResponse, t)
+  t.deepEqual(await getResponse.json(), [], 'Returns empty root directory')
+
+  // GET (versioned)
+  const versionedGetResponse = await fetch(versionedURLNoTrailingSlash)
+  await checkResponse(versionedGetResponse, t)
+  t.deepEqual(await versionedGetResponse.json(), ['example.txt', 'example2.txt'], 'Returns root directory prior to DELETE')
+})
+
 async function checkResponse (response, t, successMessage = 'Response OK') {
   if (!response.ok) {
     const message = await response.text()

--- a/test.js
+++ b/test.js
@@ -494,6 +494,7 @@ test('GET older version of file from VERSION folder', async (t) => {
 
   const fileURL = new URL(`/${fileName}`, created)
   const versionFileURL = new URL(`/$/version/2/${fileName}`, created)
+  const versionRootURL = new URL(`/$/version/1/`, created)
 
   await checkResponse(
     await fetch(fileURL, { method: 'PUT', body: data1 }), t
@@ -502,13 +503,15 @@ test('GET older version of file from VERSION folder', async (t) => {
     await fetch(fileURL, { method: 'PUT', body: data2 }), t
   )
 
-  const versionedResponse = await fetch(versionFileURL)
+  const versionedFileResponse = await fetch(versionFileURL)
+  await checkResponse(versionedFileResponse, t, 'Able to GET versioned file')
+  const versionedFileData = await versionedFileResponse.text()
+  t.equal(versionedFileData, data1, 'Old data got loaded')
 
-  await checkResponse(versionedResponse, t, 'Able to GET versioned file')
-
-  const versionedData = await versionedResponse.text()
-
-  t.equal(versionedData, data1, 'Old data got loaded')
+  const versionedRootResponse = await fetch(versionRootURL)
+  await checkResponse(versionedRootResponse, t, 'Able to GET versioned root')
+  const versionedRootContents = await versionedRootResponse.json()
+  t.deepEqual(versionedRootContents, [], 'Old root content got loaded')
 })
 
 async function checkResponse (response, t, successMessage = 'Response OK') {


### PR DESCRIPTION
- Ensure that pathnames (versioned and non-versioned) begin with `/`
- Forbid PUT to pathname with trailing slash (the previous behavior was to strip off the trailing slash before writing)
- Test