### PR TITLE
Attempts to modify old version should return `405`

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,9 @@ export default async function makeHyperFetch ({
     router.get(`hyper://${SPECIAL_DOMAIN}/`, getKey)
     router.post(`hyper://${SPECIAL_DOMAIN}/`, createKey)
 
+    router.put(`hyper://*/${SPECIAL_FOLDER}/${VERSION_FOLDER_NAME}/**`, putFilesVersioned)
     router.put('hyper://*/**', putFiles)
+    router.delete(`hyper://*/${SPECIAL_FOLDER}/${VERSION_FOLDER_NAME}/**`, deleteFilesVersioned)
     router.delete('hyper://*/**', deleteFiles)
   }
 
@@ -394,6 +396,10 @@ export default async function makeHyperFetch ({
     return { status: 201, headers: { Location: request.url } }
   }
 
+  function putFilesVersioned (request) {
+    return { status: 405, body: 'Cannot PUT file to old version', headers: { Location: request.url } }
+  }
+
   async function deleteFiles (request) {
     const { hostname, pathname: rawPathname } = new URL(request.url)
     const pathname = decodeURI(ensureLeadingSlash(rawPathname))
@@ -420,6 +426,10 @@ export default async function makeHyperFetch ({
     await drive.del(pathname)
 
     return { status: 200 }
+  }
+
+  function deleteFilesVersioned (request) {
+    return { status: 405, body: 'Cannot DELETE old version', headers: { Location: request.url } }
   }
 
   async function headFilesVersioned (request) {

--- a/test.js
+++ b/test.js
@@ -484,7 +484,7 @@ test('Error on invalid hostname', async (t) => {
   }
 })
 
-test('GET older version of file from VERSION folder', async (t) => {
+test('Old versions in VERSION folder', async (t) => {
   const created = await nextURL(t)
 
   const fileName = 'example.txt'
@@ -512,6 +512,27 @@ test('GET older version of file from VERSION folder', async (t) => {
   await checkResponse(versionedRootResponse, t, 'Able to GET versioned root')
   const versionedRootContents = await versionedRootResponse.json()
   t.deepEqual(versionedRootContents, [], 'Old root content got loaded')
+
+  // PUT on old version should fail
+  const putResponse = await fetch(versionFileURL, {
+    method: 'PUT',
+    body: SAMPLE_CONTENT
+  })
+  if (putResponse.ok) {
+    throw new Error('PUT old version of file should have failed')
+  } else {
+    t.equal(putResponse.status, 405, 'PUT old version returned status 405 Not Allowed')
+  }
+
+  // DELETE on old version should fail
+  const deleteResponse = await fetch(versionFileURL, {
+    method: 'delete'
+  })
+  if (deleteResponse.ok) {
+    throw new Error('DELETE old version of file should have failed')
+  } else {
+    t.equal(deleteResponse.status, 405, 'DELETE old version returned status 405 Not Allowed')
+  }
 })
 
 test('Handle empty string pathname', async (t) => {


### PR DESCRIPTION
Currently, `PUT`/`DELETE` to a file inside `hyper://PUBLIC-KEY/$/version/` returns status `404`. This merge request changes the response status to `405`.