### PR TITLE
Improve PUT response headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -564,7 +564,7 @@ export default async function makeHyperFetch ({
         const length = (end - start + 1)
 
         return {
-          status: 200,
+          status: 204,
           headers: {
             ...resHeaders,
             'Content-Length': `${length}`,
@@ -575,7 +575,7 @@ export default async function makeHyperFetch ({
     }
 
     return {
-      status: 200,
+      status: 204,
       headers: resHeaders
     }
   }

--- a/index.js
+++ b/index.js
@@ -394,6 +394,7 @@ export default async function makeHyperFetch ({
             }
           })
         )
+        return { status: 201, headers: await resolveFileHeaders(drive, pathname, false) }
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -555,7 +555,7 @@ export default async function makeHyperFetch ({
       resHeaders[HEADER_LAST_MODIFIED] = date.toUTCString()
     }
 
-    const size = entry.value.byteLength
+    const size = entry.value.blob.byteLength
     if (isRanged) {
       const ranges = parseRange(size, isRanged)
 

--- a/test.js
+++ b/test.js
@@ -120,6 +120,7 @@ test('HEAD request', async (t) => {
 
   await checkResponse(headResponse, t, 'Able to load HEAD')
 
+  const headersStatus = headResponse.status
   const headersEtag = headResponse.headers.get('Etag')
   const headersContentType = headResponse.headers.get('Content-Type')
   const headersContentLength = headResponse.headers.get('Content-Length')
@@ -127,6 +128,7 @@ test('HEAD request', async (t) => {
   const headersLastModified = headResponse.headers.get('Last-Modified')
   const headersLink = headResponse.headers.get('Link')
 
+  t.equal(headersStatus, 204, 'Response had expected status')
   // Version at which the file was added
   t.equal(headersEtag, '2', 'Headers got expected etag')
   t.equal(headersContentType, 'text/plain; charset=utf-8', 'Headers got expected mime type')

--- a/test.js
+++ b/test.js
@@ -143,12 +143,20 @@ test('PUT file', async (t) => {
 
   const uploadLocation = new URL('./example.txt', created)
 
-  const uploadResponse = await fetch(uploadLocation, {
+  const putResponse = await fetch(uploadLocation, {
     method: 'put',
     body: SAMPLE_CONTENT
   })
+  await checkResponse(putResponse, t, 'upload successful')
 
-  await checkResponse(uploadResponse, t, 'upload successful')
+  const putResponseETag = putResponse.headers.get('ETag')
+  const putResponseContentType = putResponse.headers.get('Content-Type')
+  const putResponseContentLength = putResponse.headers.get('Content-Length')
+  const putResponseLastModified = putResponse.headers.get('Last-Modified')
+  t.equal(putResponseETag, '2', 'Put response returned expected ETag')
+  t.equal(putResponseContentType, 'text/plain; charset=utf-8', 'Put response had expected mime type')
+  t.ok(putResponseContentLength, 'Put response had Content-Length header')
+  t.ok(putResponseLastModified, 'Put response had Last-Modified header')
 
   const uploadedContentResponse = await fetch(uploadLocation)
 


### PR DESCRIPTION
In hyperdrive.el, we need PUT responses to include headers which tell us information about the newly created entry.

Ideally, PUT requests would return all the same info that HEAD requests do. In order to implement this in a DRY manner, I refactored `serveFile` so that it can optionally return just headers.

Let me know what you think!