### PR TITLE
Add index.org and README.org to INDEX_FILES

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,9 @@ const INDEX_FILES = [
   'index.md',
   'index.gmi',
   'index.gemini',
-  'README.md'
+  'index.org',
+  'README.md',
+  'README.org'
 ]
 
 async function DEFAULT_RENDER_INDEX (url, files, fetch) {


### PR DESCRIPTION
This would be useful in `hyperdrive.el` now. Would you prefer to add support for rendering .org files in Agregore before merging this?