### PR TITLE
Pass `Date` header in PUT request to override file mtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,18 @@ Note that this is only available with the `writable: true` flag.
 
 ### `fetch('hyper://NAME/example.txt', {method: 'PUT', body: 'Hello World'})`
 
-You can add files to archives using a `PUT` method along with a `body`.
+You can add files to archives using a `PUT` method along with a
+`body`. Note that this is only available with the `writable: true`
+flag.
 
 The `body` can be any of the options supported by the Fetch API such as a `String`, `Blob`, `FormData`, or `ReadableStream`.
 
 `NAME` can either be the 52 character [z32 encoded](https://github.com/mafintosh/z32) key for a Hyperdrive or Hypercore , or a domain to parse with the [DNSLink](https://www.dnslink.io/) standard.
 
-Note that this is only available with the `writable: true` flag.
+The mtime metadata is automatically set to the current time when
+uploading. To override this value, pass a `Date` header with a value
+set to a date string according to [RFC
+7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1).
 
 An attempt to `PUT` a file to a hyperdrive which is not writable will
 fail with status `403`.

--- a/index.js
+++ b/index.js
@@ -397,6 +397,7 @@ export default async function makeHyperFetch ({
     const { hostname, pathname: rawPathname } = new URL(request.url)
     const pathname = decodeURI(ensureLeadingSlash(rawPathname))
     const contentType = request.headers.get('Content-Type') || ''
+    const mtime = Date.parse(request.headers.get('Date')) || Date.now()
     const isFormData = contentType.includes('multipart/form-data')
 
     const drive = await getDrive(`hyper://${hostname}/`, true)
@@ -404,8 +405,6 @@ export default async function makeHyperFetch ({
     if (!drive.db.feed.writable) {
       return { status: 403, body: `Cannot PUT file to read-only drive: ${drive.url}`, headers: { Location: request.url } }
     }
-
-    const mtime = Date.now()
 
     if (isFormData) {
       // It's a form! Get the files out and process them

--- a/test.js
+++ b/test.js
@@ -142,9 +142,13 @@ test('PUT file', async (t) => {
 
   const uploadLocation = new URL('./example.txt', created)
 
+  const fakeDate = new Date(Date.parse(0)).toUTCString()
   const uploadResponse = await fetch(uploadLocation, {
     method: 'put',
-    body: SAMPLE_CONTENT
+    body: SAMPLE_CONTENT,
+    headers: {
+      Date: fakeDate
+    }
   })
 
   await checkResponse(uploadResponse, t, 'upload successful')
@@ -159,7 +163,7 @@ test('PUT file', async (t) => {
 
   t.equal(contentType, 'text/plain; charset=utf-8', 'Content got expected mime type')
   t.equal(content, SAMPLE_CONTENT, 'Got uploaded content back out')
-  t.ok(lastModified, 'Last-Modified header got set')
+  t.equal(lastModified, fakeDate, 'Last-Modified header was set to value of Date header')
 })
 test('PUT FormData', async (t) => {
   const created = await nextURL(t)


### PR DESCRIPTION
Please double-check that `Date` is the correct header to use here. I see that `Date` is listed as a [forbidden header](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name).

This feature makes it easy for `hyperdrive.el` to mirror a directory of files, skipping files which have not been updated since the last upload. 