### PR TITLE
Dns resolution tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,6 @@ export default async function makeHyperFetch ({
 
     const corestore = sdk.namespace(core.id)
     const drive = new Hyperdrive(corestore, core.key)
-    console.log('drive', drive)
 
     await drive.ready()
 
@@ -170,6 +169,7 @@ export default async function makeHyperFetch ({
     })
 
     drives.set(drive.core.id, drive)
+    drives.set(drive.core.url, drive)
     drives.set(hostname, drive)
 
     return drive

--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ export default async function makeHyperFetch ({
 
     const corestore = sdk.namespace(core.id)
     const drive = new Hyperdrive(corestore, core.key)
+    console.log('drive', drive)
 
     await drive.ready()
 

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ import { once } from 'events'
 import makeHyperFetch from './index.js'
 
 const SAMPLE_CONTENT = 'Hello World'
+const DNS_DOMAIN = 'blog.mauve.moe'
 let count = 0
 function next () {
   return count++
@@ -498,7 +499,7 @@ test('EventSource extension messages', async (t) => {
 })
 
 test('Resolve DNS', async (t) => {
-  const loadResponse = await fetch('hyper://blog.mauve.moe/?noResolve')
+  const loadResponse = await fetch(`hyper://${DNS_DOMAIN}/?noResolve`)
 
   const entries = await loadResponse.json()
 
@@ -614,7 +615,7 @@ test('Handle empty string pathname', async (t) => {
 })
 
 test('Return status 403 Forbidden on attempt to modify read-only hyperdrive', async (t) => {
-  const readOnlyURL = 'hyper://blog.mauve.moe/new-file.txt'
+  const readOnlyURL = `hyper://${DNS_DOMAIN}/new-file.txt`
   const putResponse = await fetch(readOnlyURL, { method: 'PUT', body: SAMPLE_CONTENT })
   if (putResponse.ok) {
     throw new Error('PUT file to read-only drive should have failed')
@@ -633,7 +634,7 @@ test('Return status 403 Forbidden on attempt to modify read-only hyperdrive', as
 test('Check hyperdrive writability', async (t) => {
   const created = await nextURL(t)
 
-  const readOnlyRootDirectory = 'hyper://blog.mauve.moe/?noResolve'
+  const readOnlyRootDirectory = `hyper://${DNS_DOMAIN}/?noResolve`
   const readOnlyHeadResponse = await fetch(readOnlyRootDirectory, { method: 'HEAD' })
   await checkResponse(readOnlyHeadResponse, t, 'Able to load HEAD')
   const readOnlyHeadersAllow = readOnlyHeadResponse.headers.get('Allow')

--- a/test.js
+++ b/test.js
@@ -498,7 +498,7 @@ test('EventSource extension messages', async (t) => {
   t.ok(lastEventId, 'Event contained peer ID')
 })
 
-test.only('Resolve DNS', async (t) => {
+test('Resolve DNS', async (t) => {
   const loadResponse = await fetch(`hyper://${DNS_DOMAIN}/?noResolve`)
 
   const entries = await loadResponse.json()

--- a/test.js
+++ b/test.js
@@ -498,7 +498,7 @@ test('EventSource extension messages', async (t) => {
   t.ok(lastEventId, 'Event contained peer ID')
 })
 
-test('Resolve DNS', async (t) => {
+test.only('Resolve DNS', async (t) => {
   const loadResponse = await fetch(`hyper://${DNS_DOMAIN}/?noResolve`)
 
   const entries = await loadResponse.json()
@@ -506,7 +506,7 @@ test('Resolve DNS', async (t) => {
   t.ok(entries.length, 'Loaded contents with some files present')
 
   const rawLink = loadResponse.headers.get('Link').match(/<(.+)>/)[1]
-  const loadRawURLResponse = await fetch(rawLink)
+  const loadRawURLResponse = await fetch(rawLink + '?noResolve')
 
   const rawLinkEntries = await loadRawURLResponse.json()
   t.deepEqual(rawLinkEntries, entries, 'Raw link resolves to same content as DNS domain.')

--- a/test.js
+++ b/test.js
@@ -504,6 +504,12 @@ test('Resolve DNS', async (t) => {
   const entries = await loadResponse.json()
 
   t.ok(entries.length, 'Loaded contents with some files present')
+
+  const rawLink = loadResponse.headers.get('Link').match(/<(.+)>/)[1]
+  const loadRawURLResponse = await fetch(rawLink)
+
+  const rawLinkEntries = await loadRawURLResponse.json()
+  t.deepEqual(rawLinkEntries, entries, 'Raw link resolves to same content as DNS domain.')
 })
 
 test('Doing a `GET` on an invalid domain/public key should cause an error', async (t) => {


### PR DESCRIPTION
After resolving a drive by its DNS domain, subsequent attempts to load the drive fail. Currently, the test added in b2089db623ac8080a595dd74b3d9967187097b03 hangs.

Here is a diff between the two times that the `console.log` runs in b0b68141078ea4dc57aa998128d43c3b7a2f4e7f. I'm guessing that the `cores` `Map` should have only one entry: 

```
--- #<buffer 1 - drive resolved by DNS>
+++ #<buffer 2 - drive resolved by raw link>
@@ -15,7 +15,7 @@
     opened: false,
     closed: false,
     storage: [Function (anonymous)],
-    cores: Map(1) {
+    cores: Map(2) {
       '086fa67901a674176201f1eda27cca225635297c85f9626b3d23a9fdf929a0e3' => Hypercore(
         key: 92f727ef4ac96819a19bbe9030e23cabb384f828a1c3bdf91725af5bd9503433
         discoveryKey: 086fa67901a674176201f1eda27cca225635297c85f9626b3d23a9fdf929a0e3
@@ -26,7 +26,7 @@
         writable: false
         length: 724
         fork: 0
-        sessions: [ 3 ]
+        sessions: [ 4 ]
         activeRequests: [ 0 ]
         peers: [
           Peer(
@@ -36,6 +36,27 @@
             remoteCanUpgrade: true
           )
         ]
+      ),
+      '94cc58986bb7017cc09f6b49d91bfe46ac6ba4f991c6dc6cc55cecc3be771549' => Hypercore(
+        key: f74ff69c2490b931c95ed42fd4e31ab6c8d7bda6950721c9edb156fa2f973359
+        discoveryKey: 94cc58986bb7017cc09f6b49d91bfe46ac6ba4f991c6dc6cc55cecc3be771549
+        opened: true
+        closed: false
+        snapshotted: false
+        sparse: true
+        writable: false
+        length: 7073
+        fork: 0
+        sessions: [ 3 ]
+        activeRequests: [ 0 ]
+        peers: [
+          Peer(
+            remotePublicKey: 374f25cfc73eb9eb7497a1762f0409847de385e591e99355838b6abdabcb1900
+            remoteLength: 7073
+            remoteFork: 0
+            remoteCanUpgrade: true
+          )
+        ]
       )
     },
     cache: false,
@@ -64,7 +85,7 @@
       _readonly: false,
       _sessions: [Set],
       _rootStoreSessions: [Set],
-      _locks: Map(0) {},
+      _locks: [Map],
       _findingPeersCount: 0,
       _findingPeers: [],
       _isCorestore: true,
@@ -90,7 +111,9 @@
       )
     },
     _rootStoreSessions: Set(0) {},
-    _locks: Map(0) {},
+    _locks: Map(1) {
+      '086fa67901a674176201f1eda27cca225635297c85f9626b3d23a9fdf929a0e3' => [ReadWriteLock]
+    },
     _findingPeersCount: 0,
     _findingPeers: [],
     _isCorestore: true,
```